### PR TITLE
Add local Pokémon storage using Room

### DIFF
--- a/app/src/main/java/com/jnasser/pokedexapp/PokedexApp.kt
+++ b/app/src/main/java/com/jnasser/pokedexapp/PokedexApp.kt
@@ -3,6 +3,7 @@ package com.jnasser.pokedexapp
 import android.app.Application
 import android.content.Context
 import com.jnasser.core.data.di.coreDataModule
+import com.jnasser.core.database.di.databaseModule
 import com.jnasser.pokemon.presentation.di.pokemonPresentationModule
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
@@ -21,7 +22,8 @@ class PokedexApp: Application() {
             androidContext(this@PokedexApp)
             modules(
                 coreDataModule,
-                pokemonPresentationModule
+                pokemonPresentationModule,
+                databaseModule
             )
         }
     }

--- a/core/data/src/main/java/com/jnasser/core/data/repositories/OfflineFirstPokemonRepository.kt
+++ b/core/data/src/main/java/com/jnasser/core/data/repositories/OfflineFirstPokemonRepository.kt
@@ -1,21 +1,30 @@
 package com.jnasser.core.data.repositories
 
+import com.jnasser.core.domain.pokemon.datasources.LocalPokemonDataSource
 import com.jnasser.core.domain.pokemon.datasources.RemotePokemonDataSource
+import com.jnasser.core.domain.pokemon.model.Pokemon
 import com.jnasser.core.domain.pokemon.model.PokemonGeneration
 import com.jnasser.core.domain.pokemon.repositories.PokemonRepository
 import com.jnasser.core.domain.util.error_handler.DataError
 import com.jnasser.core.domain.util.result_handler.Result
+import kotlinx.coroutines.flow.Flow
 
 class OfflineFirstPokemonRepository(
-    private val remotePokemonDataSource: RemotePokemonDataSource
+    private val remotePokemonDataSource: RemotePokemonDataSource,
+    private val localPokemonDataSource: LocalPokemonDataSource
 ): PokemonRepository {
+
+    override fun getPokemons(): Flow<List<Pokemon>> = localPokemonDataSource.getPokemons()
 
     override suspend fun getPokemonListByGeneration(
         generation: Int
     ): Result<PokemonGeneration, DataError> {
         return when(val result = remotePokemonDataSource.getPokemonListByGeneration(generation)) {
             is Result.Error -> Result.Error(result.error)
-            is Result.Success -> Result.Success(result.data)
+            is Result.Success -> {
+
+                Result.Success(result.data)
+            }
         }
     }
 }

--- a/core/database/src/main/java/com/jnasser/core/database/PokemonDatabase.kt
+++ b/core/database/src/main/java/com/jnasser/core/database/PokemonDatabase.kt
@@ -2,6 +2,7 @@ package com.jnasser.core.database
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import com.jnasser.core.database.daos.PokemonDao
 
 @Database(
     entities = [
@@ -10,5 +11,5 @@ import androidx.room.RoomDatabase
     version = RoomConstants.POKEMON_ROOM_DB_VERSION
 )
 abstract class PokemonDatabase: RoomDatabase() {
-
+    abstract val pokemonDao: PokemonDao
 }

--- a/core/database/src/main/java/com/jnasser/core/database/PokemonDatabase.kt
+++ b/core/database/src/main/java/com/jnasser/core/database/PokemonDatabase.kt
@@ -1,0 +1,14 @@
+package com.jnasser.core.database
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+
+@Database(
+    entities = [
+
+    ],
+    version = RoomConstants.POKEMON_ROOM_DB_VERSION
+)
+abstract class PokemonDatabase: RoomDatabase() {
+
+}

--- a/core/database/src/main/java/com/jnasser/core/database/RoomConstants.kt
+++ b/core/database/src/main/java/com/jnasser/core/database/RoomConstants.kt
@@ -1,0 +1,5 @@
+package com.jnasser.core.database
+
+object RoomConstants {
+    const val POKEMON_ROOM_DB_VERSION = 1
+}

--- a/core/database/src/main/java/com/jnasser/core/database/daos/PokemonDao.kt
+++ b/core/database/src/main/java/com/jnasser/core/database/daos/PokemonDao.kt
@@ -20,14 +20,14 @@ interface PokemonDao {
      */
     @Transaction
     @Query("SELECT * FROM pokemon_entity")
-    suspend fun getAllWithTypesAndStats(): Flow<List<PokemonWithTypesAndStats>>
+    fun getAllWithTypesAndStats(): Flow<List<PokemonWithTypesAndStats>>
 
     @Upsert
-    suspend fun upsertPokemon(pokemon: PokemonEntity)
+    suspend fun upsertPokemon(pokemon: PokemonEntity): Long
 
     @Upsert
-    suspend fun upsertPokemonTypes(types: List<PokemonTypeEntity>)
+    suspend fun upsertPokemonTypes(types: List<PokemonTypeEntity>): List<Long>
 
     @Upsert
-    suspend fun upsertPokemonStats(stats: List<PokemonStatEntity>)
+    suspend fun upsertPokemonStats(stats: List<PokemonStatEntity>): List<Long>
 }

--- a/core/database/src/main/java/com/jnasser/core/database/daos/PokemonDao.kt
+++ b/core/database/src/main/java/com/jnasser/core/database/daos/PokemonDao.kt
@@ -1,0 +1,33 @@
+package com.jnasser.core.database.daos
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import androidx.room.Transaction
+import androidx.room.Upsert
+import com.jnasser.core.database.entities.PokemonEntity
+import com.jnasser.core.database.entities.PokemonStatEntity
+import com.jnasser.core.database.entities.PokemonTypeEntity
+import com.jnasser.core.database.entities.PokemonWithTypesAndStats
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface PokemonDao {
+
+    /**
+     * Returns all Pokémon with their associated types and stats.
+     * This is a transactional query to fetch relations together.
+     */
+    @Transaction
+    @Query("SELECT * FROM pokemon_entity")
+    suspend fun getAllWithTypesAndStats(): Flow<List<PokemonWithTypesAndStats>>
+
+    @Upsert
+    suspend fun upsertPokemon(pokemon: PokemonEntity)
+
+    @Upsert
+    suspend fun upsertPokemonTypes(types: List<PokemonTypeEntity>)
+
+    @Upsert
+    suspend fun upsertPokemonStats(stats: List<PokemonStatEntity>)
+}

--- a/core/database/src/main/java/com/jnasser/core/database/datasources/RoomPokemonDataSource.kt
+++ b/core/database/src/main/java/com/jnasser/core/database/datasources/RoomPokemonDataSource.kt
@@ -1,0 +1,88 @@
+package com.jnasser.core.database.datasources
+
+import android.database.sqlite.SQLiteFullException
+import com.jnasser.core.database.daos.PokemonDao
+import com.jnasser.core.database.mappers.toPokemon
+import com.jnasser.core.database.mappers.toPokemonEntity
+import com.jnasser.core.database.mappers.toPokemonStatEntity
+import com.jnasser.core.database.mappers.toPokemonTypeEntity
+import com.jnasser.core.domain.pokemon.datasources.LocalPokemonDataSource
+import com.jnasser.core.domain.pokemon.model.Pokemon
+import com.jnasser.core.domain.pokemon.model.PokemonStat
+import com.jnasser.core.domain.pokemon.model.PokemonType
+import com.jnasser.core.domain.util.error_handler.DataError
+import com.jnasser.core.domain.util.result_handler.Result
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+/**
+ * Local data source implementation that uses Room to store and retrieve Pokémon data.
+ * Handles persistence of Pokémon, their types, and stats.
+ */
+class RoomPokemonDataSource(
+    private val pokemonDao: PokemonDao
+) : LocalPokemonDataSource {
+
+    /**
+     * Retrieves all Pokémon stored in the local database along with their types and stats.
+     *
+     * @return A flow of Pokémon list mapped to the domain model.
+     */
+    override fun getPokemons(): Flow<List<Pokemon>> {
+        return pokemonDao.getAllWithTypesAndStats()
+            .map { pokemonEntities ->
+                pokemonEntities.map { it.toPokemon() }
+            }
+    }
+
+    /**
+     * Inserts or updates a Pokémon entity in the database.
+     *
+     * @param pokemon The domain model to persist.
+     * @return [Result] indicating success or disk full error.
+     *          If the result contains -1L, it means an error occurred while saving to Room.
+     */
+    override suspend fun upsertPokemon(pokemon: Pokemon): Result<Boolean, DataError.Local> {
+        return try {
+            val entity = pokemon.toPokemonEntity()
+            val result = pokemonDao.upsertPokemon(entity)
+            Result.Success(result != -1L)
+        } catch (e: SQLiteFullException) {
+            Result.Error(DataError.Local.DISK_FULL)
+        }
+    }
+
+    /**
+     * Inserts or updates a list of Pokémon types in the database.
+     *
+     * @param types The list of domain model types to persist.
+     * @return [Result] indicating partial success or disk full error.
+     *          If the result contains at least one -1L, it means an error occurred while saving to Room.
+     */
+    override suspend fun upsertPokemonTypes(types: List<PokemonType>): Result<Boolean, DataError.Local> {
+        return try {
+            val entity = types.map { it.toPokemonTypeEntity() }
+            val result = pokemonDao.upsertPokemonTypes(entity)
+            Result.Success(result.any { it != -1L })
+        } catch (e: SQLiteFullException) {
+            Result.Error(DataError.Local.DISK_FULL)
+        }
+    }
+
+    /**
+     * Inserts or updates a list of Pokémon stats in the database.
+     *
+     * @param stats The list of domain model stats to persist.
+     * @return [Result] indicating partial success or disk full error.
+     *          If the result contains at least one -1L, it means an error occurred while saving to Room.
+     */
+    override suspend fun upsertPokemonStats(stats: List<PokemonStat>): Result<Boolean, DataError.Local> {
+        return try {
+            val entity = stats.map { it.toPokemonStatEntity() }
+            val result = pokemonDao.upsertPokemonStats(entity)
+            Result.Success(result.any { it != -1L })
+        } catch (e: SQLiteFullException) {
+            Result.Error(DataError.Local.DISK_FULL)
+        }
+    }
+}

--- a/core/database/src/main/java/com/jnasser/core/database/di/DatabaseModule.kt
+++ b/core/database/src/main/java/com/jnasser/core/database/di/DatabaseModule.kt
@@ -15,4 +15,6 @@ val databaseModule = module {
             POKEMON_ROOM_DB_NAME
         ).build()
     }
+
+    single { get<PokemonDatabase>().pokemonDao }
 }

--- a/core/database/src/main/java/com/jnasser/core/database/di/DatabaseModule.kt
+++ b/core/database/src/main/java/com/jnasser/core/database/di/DatabaseModule.kt
@@ -2,7 +2,11 @@ package com.jnasser.core.database.di
 
 import androidx.room.Room
 import com.jnasser.core.database.PokemonDatabase
+import com.jnasser.core.database.datasources.RoomPokemonDataSource
+import com.jnasser.core.domain.pokemon.datasources.LocalPokemonDataSource
 import org.koin.android.ext.koin.androidApplication
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
 import org.koin.dsl.module
 
 private const val POKEMON_ROOM_DB_NAME = "pokemon.db"
@@ -17,4 +21,6 @@ val databaseModule = module {
     }
 
     single { get<PokemonDatabase>().pokemonDao }
+
+    singleOf(::RoomPokemonDataSource).bind<LocalPokemonDataSource>()
 }

--- a/core/database/src/main/java/com/jnasser/core/database/di/DatabaseModule.kt
+++ b/core/database/src/main/java/com/jnasser/core/database/di/DatabaseModule.kt
@@ -1,0 +1,18 @@
+package com.jnasser.core.database.di
+
+import androidx.room.Room
+import com.jnasser.core.database.PokemonDatabase
+import org.koin.android.ext.koin.androidApplication
+import org.koin.dsl.module
+
+private const val POKEMON_ROOM_DB_NAME = "pokemon.db"
+
+val databaseModule = module {
+    single {
+        Room.databaseBuilder(
+            androidApplication(),
+            PokemonDatabase::class.java,
+            POKEMON_ROOM_DB_NAME
+        ).build()
+    }
+}

--- a/core/database/src/main/java/com/jnasser/core/database/entities/PokemonEntity.kt
+++ b/core/database/src/main/java/com/jnasser/core/database/entities/PokemonEntity.kt
@@ -1,0 +1,15 @@
+package com.jnasser.core.database.entities
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "pokemon_entity")
+data class PokemonEntity(
+    @PrimaryKey(autoGenerate = false)
+    val id: Long,
+    val name: String,
+    val imageUrl: String,
+    val height: Int,
+    val weight: Int,
+    val description: String
+)

--- a/core/database/src/main/java/com/jnasser/core/database/entities/PokemonStatEntity.kt
+++ b/core/database/src/main/java/com/jnasser/core/database/entities/PokemonStatEntity.kt
@@ -1,0 +1,27 @@
+package com.jnasser.core.database.entities
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+
+/**
+ * Represents a base stat (e.g. "attack", "defense") for a specific Pokémon.
+ * Uses a composite primary key (pokemonId + name) to allow multiple stats per Pokémon.
+ * Stats are deleted automatically when the related Pokémon is removed.
+ */
+@Entity(
+    tableName = "pokemon_stat_entity",
+    primaryKeys = ["pokemonId", "name"],
+    foreignKeys = [
+        ForeignKey(
+            entity = PokemonEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["pokemonId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ]
+)
+data class PokemonStatEntity(
+    val pokemonId: Long,
+    val baseStat: Int,
+    val name: String
+)

--- a/core/database/src/main/java/com/jnasser/core/database/entities/PokemonTypeEntity.kt
+++ b/core/database/src/main/java/com/jnasser/core/database/entities/PokemonTypeEntity.kt
@@ -1,0 +1,26 @@
+package com.jnasser.core.database.entities
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+
+/**
+ * Represents a base type (e.g. "fire", "poison") for a specific Pokémon.
+ * Uses a composite primary key (pokemonId + type) to allow multiple types per Pokémon.
+ * Types are deleted automatically when the related Pokémon is removed.
+ */
+@Entity(
+    tableName = "pokemon_type_entity",
+    primaryKeys = ["pokemonId", "type"],
+    foreignKeys = [
+        ForeignKey(
+            entity = PokemonEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["pokemonId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ]
+)
+data class PokemonTypeEntity(
+    val pokemonId: Long,
+    val type: String
+)

--- a/core/database/src/main/java/com/jnasser/core/database/entities/PokemonWithTypesAndStats.kt
+++ b/core/database/src/main/java/com/jnasser/core/database/entities/PokemonWithTypesAndStats.kt
@@ -1,0 +1,18 @@
+package com.jnasser.core.database.entities
+
+import androidx.room.Embedded
+import androidx.room.Relation
+
+data class PokemonWithTypesAndStats(
+    @Embedded val pokemon: PokemonEntity,
+    @Relation(
+        parentColumn = "id",
+        entityColumn = "pokemonId"
+    )
+    val types: List<PokemonTypeEntity>,
+    @Relation(
+        parentColumn = "id",
+        entityColumn = "pokemonId"
+    )
+    val stats: List<PokemonStatEntity>
+)

--- a/core/database/src/main/java/com/jnasser/core/database/mappers/PokemonMappers.kt
+++ b/core/database/src/main/java/com/jnasser/core/database/mappers/PokemonMappers.kt
@@ -1,0 +1,51 @@
+package com.jnasser.core.database.mappers
+
+import com.jnasser.core.database.entities.PokemonEntity
+import com.jnasser.core.database.entities.PokemonStatEntity
+import com.jnasser.core.database.entities.PokemonTypeEntity
+import com.jnasser.core.database.entities.PokemonWithTypesAndStats
+import com.jnasser.core.domain.pokemon.model.Pokemon
+import com.jnasser.core.domain.pokemon.model.PokemonStat
+import com.jnasser.core.domain.pokemon.model.PokemonType
+
+fun PokemonWithTypesAndStats.toPokemon() = Pokemon(
+    id = pokemon.id,
+    name = pokemon.name,
+    imageUrl = pokemon.imageUrl,
+    height = pokemon.height,
+    weight = pokemon.weight,
+    description = pokemon.description,
+    types = types.map { it.toPokemonType() },
+    stats = stats.map { it.toPokemonStat() }
+)
+
+fun PokemonTypeEntity.toPokemonType() = PokemonType(
+    pokemonId = pokemonId,
+    type = type
+)
+
+fun PokemonStatEntity.toPokemonStat() = PokemonStat(
+    pokemonId = pokemonId,
+    name = name,
+    baseStat = baseStat
+)
+
+fun Pokemon.toPokemonEntity() = PokemonEntity(
+    id = id,
+    name = name,
+    imageUrl = imageUrl,
+    height = height,
+    weight = weight,
+    description = description
+)
+
+fun PokemonType.toPokemonTypeEntity() = PokemonTypeEntity(
+    pokemonId = pokemonId,
+    type = type
+)
+
+fun PokemonStat.toPokemonStatEntity() = PokemonStatEntity(
+    pokemonId = pokemonId,
+    baseStat = baseStat,
+    name = name
+)

--- a/core/domain/src/main/java/com/jnasser/core/domain/pokemon/datasources/LocalPokemonDataSource.kt
+++ b/core/domain/src/main/java/com/jnasser/core/domain/pokemon/datasources/LocalPokemonDataSource.kt
@@ -1,5 +1,15 @@
 package com.jnasser.core.domain.pokemon.datasources
 
-interface LocalPokemonDataSource {
+import com.jnasser.core.domain.pokemon.model.Pokemon
+import com.jnasser.core.domain.pokemon.model.PokemonStat
+import com.jnasser.core.domain.pokemon.model.PokemonType
+import com.jnasser.core.domain.util.error_handler.DataError
+import com.jnasser.core.domain.util.result_handler.Result
+import kotlinx.coroutines.flow.Flow
 
+interface LocalPokemonDataSource {
+    fun getPokemons(): Flow<List<Pokemon>>
+    suspend fun upsertPokemon(pokemon: Pokemon): Result<Boolean, DataError.Local>
+    suspend fun upsertPokemonTypes(types: List<PokemonType>): Result<Boolean, DataError.Local>
+    suspend fun upsertPokemonStats(stats: List<PokemonStat>): Result<Boolean, DataError.Local>
 }

--- a/core/domain/src/main/java/com/jnasser/core/domain/pokemon/model/Pokemon.kt
+++ b/core/domain/src/main/java/com/jnasser/core/domain/pokemon/model/Pokemon.kt
@@ -1,6 +1,12 @@
 package com.jnasser.core.domain.pokemon.model
 
 data class Pokemon(
+    val id: Long,
     val name: String,
-    val url: String
+    val imageUrl: String,
+    val height: Int,
+    val weight: Int,
+    val description: String,
+    val types: List<PokemonType>,
+    val stats: List<PokemonStat>
 )

--- a/core/domain/src/main/java/com/jnasser/core/domain/pokemon/model/PokemonGeneration.kt
+++ b/core/domain/src/main/java/com/jnasser/core/domain/pokemon/model/PokemonGeneration.kt
@@ -1,5 +1,5 @@
 package com.jnasser.core.domain.pokemon.model
 
 data class PokemonGeneration(
-    val pokemonSpecies: List<Pokemon>
+    val pokemonGenerationDetailSpecies: List<PokemonGenerationDetail>
 )

--- a/core/domain/src/main/java/com/jnasser/core/domain/pokemon/model/PokemonGenerationDetail.kt
+++ b/core/domain/src/main/java/com/jnasser/core/domain/pokemon/model/PokemonGenerationDetail.kt
@@ -1,0 +1,6 @@
+package com.jnasser.core.domain.pokemon.model
+
+data class PokemonGenerationDetail(
+    val name: String,
+    val url: String
+)

--- a/core/domain/src/main/java/com/jnasser/core/domain/pokemon/model/PokemonStat.kt
+++ b/core/domain/src/main/java/com/jnasser/core/domain/pokemon/model/PokemonStat.kt
@@ -1,0 +1,7 @@
+package com.jnasser.core.domain.pokemon.model
+
+data class PokemonStat(
+    val pokemonId: Long,
+    val baseStat: Int,
+    val name: String
+)

--- a/core/domain/src/main/java/com/jnasser/core/domain/pokemon/model/PokemonType.kt
+++ b/core/domain/src/main/java/com/jnasser/core/domain/pokemon/model/PokemonType.kt
@@ -1,0 +1,6 @@
+package com.jnasser.core.domain.pokemon.model
+
+data class PokemonType(
+    val pokemonId: Long,
+    val type: String
+)

--- a/core/domain/src/main/java/com/jnasser/core/domain/pokemon/repositories/PokemonRepository.kt
+++ b/core/domain/src/main/java/com/jnasser/core/domain/pokemon/repositories/PokemonRepository.kt
@@ -1,14 +1,25 @@
 package com.jnasser.core.domain.pokemon.repositories
 
+import com.jnasser.core.domain.pokemon.model.Pokemon
 import com.jnasser.core.domain.pokemon.model.PokemonGeneration
+import com.jnasser.core.domain.pokemon.model.PokemonStat
+import com.jnasser.core.domain.pokemon.model.PokemonType
 import com.jnasser.core.domain.util.error_handler.DataError
 import com.jnasser.core.domain.util.result_handler.Result
+import kotlinx.coroutines.flow.Flow
 
 /**
  * Repository interface for accessing Pokémon data.
  * Acts as an abstraction between the domain layer and data sources.
  */
 interface PokemonRepository {
+
+    /**
+     * Retrieves the list of Pokémon stored locally.
+     *
+     * @return A [Flow] emitting the list of Pokémon.
+     */
+    fun getPokemons(): Flow<List<Pokemon>>
 
     /**
      * Retrieves the list of Pokémon for a specific generation.

--- a/pokemon/network/src/main/java/com/jnasser/pokemon/network/mappers/PokemonMappers.kt
+++ b/pokemon/network/src/main/java/com/jnasser/pokemon/network/mappers/PokemonMappers.kt
@@ -1,6 +1,6 @@
 package com.jnasser.pokemon.network.mappers
 
-import com.jnasser.core.domain.pokemon.model.Pokemon
+import com.jnasser.core.domain.pokemon.model.PokemonGenerationDetail
 import com.jnasser.core.domain.pokemon.model.PokemonGeneration
 import com.jnasser.pokemon.network.model.PokemonDto
 import com.jnasser.pokemon.network.model.PokemonGenerationDto
@@ -8,10 +8,10 @@ import com.jnasser.pokemon.network.model.PokemonGenerationDto
 fun List<PokemonDto>.toPokemonList() = map(PokemonDto::toPokemon)
 
 fun PokemonGenerationDto.toPokemonGeneration() = PokemonGeneration(
-    pokemonSpecies = pokemonSpecies.toPokemonList()
+    pokemonGenerationDetailSpecies = pokemonSpecies.toPokemonList()
 )
 
-fun PokemonDto.toPokemon() = Pokemon(
+fun PokemonDto.toPokemon() = PokemonGenerationDetail(
     name = name,
     url = url
 )

--- a/pokemon/presentation/src/main/java/com/jnasser/pokemon/presentation/pokemon_list/mappers/PokemonMappers.kt
+++ b/pokemon/presentation/src/main/java/com/jnasser/pokemon/presentation/pokemon_list/mappers/PokemonMappers.kt
@@ -1,8 +1,5 @@
 package com.jnasser.pokemon.presentation.pokemon_list.mappers
 
-import com.jnasser.core.domain.pokemon.model.Pokemon
-import com.jnasser.pokemon.presentation.pokemon_list.model.PokemonDataUi
-
 /*
 fun Pokemon.toPokemonDataUi() = PokemonDataUi(
 


### PR DESCRIPTION
This PR introduces local persistence for Pokémon data using Room. It includes:

- Room entities: PokemonEntity, PokemonTypeEntity, and PokemonStatEntity
- Relation model: PokemonWithTypesAndStats
- DAO with upsert operations and transactional retrieval
- RoomPokemonDataSource implementation for LocalPokemonDataSource
- Error handling for SQLiteFullException
