### PR TITLE
Set up navigation between Pokémon list and detail screens

### DIFF
--- a/app/src/main/java/com/jnasser/pokedexapp/MainActivity.kt
+++ b/app/src/main/java/com/jnasser/pokedexapp/MainActivity.kt
@@ -11,7 +11,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.compose.rememberNavController
 import com.jnasser.core.presentation.designsystem.theme.PokedexAppTheme
+import com.jnasser.pokedexapp.navigation.NavigationRoot
 import com.jnasser.pokemon.presentation.pokemon_detail.composables.PokemonDetailScreenRoot
 import com.jnasser.pokemon.presentation.pokemon_list.composables.PokemonListScreenRoot
 
@@ -21,7 +23,10 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             PokedexAppTheme {
-                PokemonDetailScreenRoot()
+                val navController = rememberNavController()
+                NavigationRoot(
+                    navController = navController
+                )
             }
         }
     }

--- a/app/src/main/java/com/jnasser/pokedexapp/navigation/NavigationRoot.kt
+++ b/app/src/main/java/com/jnasser/pokedexapp/navigation/NavigationRoot.kt
@@ -1,0 +1,58 @@
+package com.jnasser.pokedexapp.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.navigation
+import androidx.navigation.toRoute
+import com.jnasser.pokemon.presentation.pokemon_detail.composables.PokemonDetailScreenRoot
+import com.jnasser.pokemon.presentation.pokemon_list.composables.PokemonListScreenRoot
+import kotlinx.serialization.Serializable
+import timber.log.Timber
+
+@Serializable
+data object PokemonGraphRoute
+
+@Composable
+fun NavigationRoot(
+    navController: NavHostController
+) {
+    NavHost(
+        navController = navController,
+        startDestination = PokemonGraphRoute
+    ) {
+        pokemonGraph(navController)
+    }
+}
+
+@Serializable
+data object PokemonListRoute
+
+@Serializable
+data class PokemonDetailRoute(val pokemonId: Int)
+
+private fun NavGraphBuilder.pokemonGraph(navController: NavHostController) {
+    navigation<PokemonGraphRoute>(
+        startDestination = PokemonListRoute
+    ) {
+        composable<PokemonListRoute> {
+            PokemonListScreenRoot(
+                onPokemonDetail = { pokemonId ->
+                    navController.navigate(PokemonDetailRoute(pokemonId))
+                }
+            )
+        }
+        composable<PokemonDetailRoute> { data ->
+            val pokemonId = data.toRoute<PokemonDetailRoute>().pokemonId
+            PokemonDetailScreenRoot(
+                pokemonId = pokemonId,
+                onReturn = {
+                    navController.navigateUp()
+                }
+            )
+        }
+    }
+}

--- a/pokemon/presentation/src/main/java/com/jnasser/pokemon/presentation/pokemon_detail/PokemonDetailViewModel.kt
+++ b/pokemon/presentation/src/main/java/com/jnasser/pokemon/presentation/pokemon_detail/PokemonDetailViewModel.kt
@@ -16,10 +16,4 @@ class PokemonDetailViewModel(
 
     private val eventChannel = Channel<PokemonDetailEvent>()
     val events = eventChannel.receiveAsFlow()
-
-    fun onAction(action: PokemonDetailAction) {
-        when(action) {
-            PokemonDetailAction.OnReturn -> TODO()
-        }
-    }
 }

--- a/pokemon/presentation/src/main/java/com/jnasser/pokemon/presentation/pokemon_detail/composables/PokemonDetailScreen.kt
+++ b/pokemon/presentation/src/main/java/com/jnasser/pokemon/presentation/pokemon_detail/composables/PokemonDetailScreen.kt
@@ -37,7 +37,9 @@ import org.koin.androidx.compose.koinViewModel
 
 @Composable
 fun PokemonDetailScreenRoot(
-    viewModel: PokemonDetailViewModel = koinViewModel()
+    viewModel: PokemonDetailViewModel = koinViewModel(),
+    pokemonId: Int,
+    onReturn: () -> Unit
 ) {
     val context = LocalContext.current
     ObserveAsEvents(viewModel.events) { event ->
@@ -53,7 +55,9 @@ fun PokemonDetailScreenRoot(
     PokemonDetailScreen(
         state = viewModel.state,
         onAction = { action ->
-            viewModel.onAction(action)
+            when(action) {
+                PokemonDetailAction.OnReturn -> onReturn()
+            }
         }
     )
 }
@@ -70,7 +74,9 @@ fun PokemonDetailScreen(
                 config = PokedexTopAppBarConfig(
                     title = state.pokemonDetail.name,
                     centerTitle = false,
-                    navigationIcon = PokedexTopAppBar.NavigationIcon.Up {},
+                    navigationIcon = PokedexTopAppBar.NavigationIcon.Up {
+                        onAction(PokemonDetailAction.OnReturn)
+                    },
                     actions = listOf(
                         PokedexTopAppBar.Action(
                             text = state.pokemonDetail.number,
@@ -87,7 +93,9 @@ fun PokemonDetailScreen(
         )
 
         LazyColumn(
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize(),
             contentPadding = PaddingValues(20.dp)
         ) {
             item {

--- a/pokemon/presentation/src/main/java/com/jnasser/pokemon/presentation/pokemon_list/PokemonListViewModel.kt
+++ b/pokemon/presentation/src/main/java/com/jnasser/pokemon/presentation/pokemon_list/PokemonListViewModel.kt
@@ -39,8 +39,8 @@ class PokemonListViewModel(
 
     fun onAction(action: PokemonListAction) {
         when(action) {
-            is PokemonListAction.OnPokemonDetail -> TODO()
             is PokemonListAction.OnSearch -> onSearch(action.query)
+            else -> Unit
         }
     }
 

--- a/pokemon/presentation/src/main/java/com/jnasser/pokemon/presentation/pokemon_list/composables/PokemonItem.kt
+++ b/pokemon/presentation/src/main/java/com/jnasser/pokemon/presentation/pokemon_list/composables/PokemonItem.kt
@@ -72,7 +72,7 @@ fun PokemonItem(
                         top.linkTo(parent.top)
                     }
                 ,
-                text = stringResource(R.string.pokemon_number, pokemon.number),
+                text = stringResource(R.string.pokemon_number, pokemon.number.padStart(3, '0')),
                 color = PokedexColors.Gray200,
                 style = MaterialTheme.typography.bodyMedium.copy(
                     fontWeight = FontWeight.Normal

--- a/pokemon/presentation/src/main/java/com/jnasser/pokemon/presentation/pokemon_list/composables/PokemonList.kt
+++ b/pokemon/presentation/src/main/java/com/jnasser/pokemon/presentation/pokemon_list/composables/PokemonList.kt
@@ -14,7 +14,8 @@ import com.jnasser.pokemon.presentation.pokemon_list.model.PokemonListDataUi
 @Composable
 fun PokemonList(
     modifier: Modifier = Modifier,
-    pokemonList: List<PokemonListDataUi>
+    pokemonList: List<PokemonListDataUi>,
+    onPokemonClick: (Int) -> Unit
 ) {
     LazyVerticalGrid(
         modifier = modifier.fillMaxSize(),
@@ -27,7 +28,7 @@ fun PokemonList(
             PokemonItem(
                 pokemon = item,
                 onClick = { number ->
-
+                    number.toIntOrNull()?.let { onPokemonClick(it) }
                 }
             )
         }

--- a/pokemon/presentation/src/main/java/com/jnasser/pokemon/presentation/pokemon_list/composables/PokemonListScreen.kt
+++ b/pokemon/presentation/src/main/java/com/jnasser/pokemon/presentation/pokemon_list/composables/PokemonListScreen.kt
@@ -43,7 +43,8 @@ import org.koin.androidx.compose.koinViewModel
 
 @Composable
 fun PokemonListScreenRoot(
-    viewModel: PokemonListViewModel = koinViewModel()
+    viewModel: PokemonListViewModel = koinViewModel(),
+    onPokemonDetail: (Int) -> Unit
 ) {
     val context = LocalContext.current
     ObserveAsEvents(viewModel.events) { event ->
@@ -59,6 +60,10 @@ fun PokemonListScreenRoot(
     PokemonListScreen(
         state = viewModel.state,
         onAction = { action ->
+            when(action) {
+                is PokemonListAction.OnPokemonDetail -> onPokemonDetail(action.id)
+                else -> Unit
+            }
             viewModel.onAction(action)
         }
     )
@@ -110,7 +115,10 @@ fun PokemonListScreen(
                     )
                 )
                 PokemonList(
-                    pokemonList = state.filteredPokemonList
+                    pokemonList = state.filteredPokemonList,
+                    onPokemonClick = { pokemonId ->
+                        onAction(PokemonListAction.OnPokemonDetail(pokemonId))
+                    }
                 )
             }
         }

--- a/pokemon/presentation/src/main/java/com/jnasser/pokemon/presentation/pokemon_list/mappers/PokemonMappers.kt
+++ b/pokemon/presentation/src/main/java/com/jnasser/pokemon/presentation/pokemon_list/mappers/PokemonMappers.kt
@@ -6,5 +6,5 @@ import com.jnasser.pokemon.presentation.pokemon_list.model.PokemonListDataUi
 fun Pokemon.toPokemonDataUi() = PokemonListDataUi(
     name = name,
     imageUrl = imageUrl,
-    number = id.toString().padStart(3, '0')
+    number = id.toString()
 )


### PR DESCRIPTION
This PR introduces the navigation setup for the Pokedex app:

- Created navigation graph and route definitions
- Connected the Pokémon list screen to the detail screen
- Passed required arguments between screens
- Ensured type-safe and modular navigation structure
